### PR TITLE
Fix jQuery ready handler

### DIFF
--- a/static/movies/app.js
+++ b/static/movies/app.js
@@ -38,5 +38,5 @@ function main() {
     modal();
 }
 
-$(document).ready(main());
+$(document).ready(main);
 


### PR DESCRIPTION
## Summary
- correctly pass function to `$(document).ready`

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684509dd2b48832c82db01cbe939f1b5